### PR TITLE
Fix fixture loading & updated requirements

### DIFF
--- a/TWLight/emails/tasks.py
+++ b/TWLight/emails/tasks.py
@@ -329,6 +329,10 @@ def notify_applicants_when_waitlisted(sender, instance, **kwargs):
     When Partners are switched to WAITLIST status, anyone with open applications
     should be notified.
     """
+    # If this is a fixture being loaded, don't continue processing the signal.
+    if kwargs.get('raw'):
+        return
+
     if instance.id:
         orig_partner = get_object_or_404(Partner, pk=instance.id)
 

--- a/TWLight/resources/fixtures/8.yaml
+++ b/TWLight/resources/fixtures/8.yaml
@@ -1,5 +1,6 @@
 - model: resources.partner
   pk: 8
   fields:
-    company_name: Foreign Affairs
-    company_location: United States of America
+    company_name: "Foreign Affairs"
+    company_location: "US"
+    date_created: "2019-01-01"

--- a/TWLight/resources/fixtures/8.yaml
+++ b/TWLight/resources/fixtures/8.yaml
@@ -1,6 +1,0 @@
-- model: resources.partner
-  pk: 8
-  fields:
-    company_name: "Foreign Affairs"
-    company_location: "US"
-    date_created: "2019-01-01"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,5 @@
 bleach==3.1.0
+beautifulsoup4==4.7.1
 defusedxml==0.5.0
 django>=1.11.19,<2.0
 django-autocomplete-light>=3.2.10,<3.3
@@ -24,5 +25,5 @@ python-dateutil==2.8.0
 beautifulsoup4
 pytz==2018.9
 six==1.12.0
-vcrpy
+vcrpy==2.0.1
 wheel==0.33.0


### PR DESCRIPTION
Was just pulling this down to check out your test error and the lack of bs4 + vcrpy requirements got in my way.

I believe I've managed to fix the fixture loading too. The issue was that `pre_save` was being triggered when the fixture was being loaded and Django got confused. Luckily there's a way of checking if a signal is sent from an internal Django process (i.e. fixture loading) and we can just avoid doing anything with the signal.

After fixing that Django started complaining about the fixture itself, so I fixed up the data there, and tests passed again.